### PR TITLE
Change: handling of Dispose of handlers

### DIFF
--- a/src/ZeroMessenger/AsyncSubscribeStrategy.cs
+++ b/src/ZeroMessenger/AsyncSubscribeStrategy.cs
@@ -14,7 +14,7 @@ internal sealed class SequentialAsyncMessageHandler<T>(AsyncMessageHandler<T> ha
 
     protected override async ValueTask HandleAsyncCore(T message, CancellationToken cancellationToken = default)
     {
-        await publishLock.WaitAsync();
+        await publishLock.WaitAsync(cancellationToken);
         try
         {
             await handler.HandleAsync(message, cancellationToken);
@@ -25,9 +25,8 @@ internal sealed class SequentialAsyncMessageHandler<T>(AsyncMessageHandler<T> ha
         }
     }
 
-    public override void Dispose()
+    protected override void DisposeCore()
     {
-        base.Dispose();
         publishLock.Dispose();
     }
 }

--- a/src/ZeroMessenger/FilteredHandlers.cs
+++ b/src/ZeroMessenger/FilteredHandlers.cs
@@ -8,6 +8,11 @@ internal sealed class FilteredMessageHandler<T>(MessageHandler<T> handler, IMess
         return new FilterIterator(handler, filters).InvokeRecursiveAsync(message, cancellationToken);
     }
 
+    protected override void DisposeCore()
+    {
+        handler.Dispose();
+    }
+
     struct FilterIterator(MessageHandler<T> handler, IMessageFilter<T>[] filters)
     {
         int index;

--- a/src/ZeroMessenger/MessageHandlerNode.cs
+++ b/src/ZeroMessenger/MessageHandlerNode.cs
@@ -12,12 +12,20 @@ public abstract class MessageHandlerNode<T> : IDisposable
     bool disposed;
     public bool IsDisposed => disposed;
 
-    public virtual void Dispose()
+    public void Dispose()
     {
         ThrowHelper.ThrowObjectDisposedIf(IsDisposed, typeof(MessageHandlerNode<T>));
 
-        Parent.Remove(this);
+        if (Parent != null)
+        {
+            Parent.Remove(this);
+            Volatile.Write(ref Parent!, null);
+        }
+
         Volatile.Write(ref disposed, true);
-        Volatile.Write(ref Parent!, null);
+
+        DisposeCore();
     }
+
+    protected virtual void DisposeCore() { }
 }

--- a/src/ZeroMessenger/MessageSubscriberAsyncExtensions.cs
+++ b/src/ZeroMessenger/MessageSubscriberAsyncExtensions.cs
@@ -113,9 +113,8 @@ internal class AsyncEnumerableMessageHandler<T>(ChannelWriter<T> writer) : Messa
         writer.TryWrite(message);
     }
 
-    public override void Dispose()
+    protected override void DisposeCore()
     {
-        base.Dispose();
         registration.Dispose();
     }
 }


### PR DESCRIPTION
Related to #8, to address the issue where Dispose of the internal handler is not called when creating a `FilteredMessageHandler`, we introduce a definition of `DisposeCore`. This ensures that Dispose of the base class is called.